### PR TITLE
Correct endpoint URL in emr-hadoop-spark-jobs

### DIFF
--- a/emr-hadoop-spark-jobs/job/src/main/java/TestJob.java
+++ b/emr-hadoop-spark-jobs/job/src/main/java/TestJob.java
@@ -10,7 +10,9 @@ public class TestJob {
     public static void uploadFile(String object_key, String from_bucket, String to_bucket) {
         AWSCredentials credentials = new BasicAWSCredentials("foo", "foo");
         String region = System.getenv().get("AWS_REGION");
-        String s3URL = System.getenv().get("TEST_S3_URL");
+        String lsHost = System.getenv().get("LOCALSTACK_HOSTNAME");
+        String edgePort = System.getenv().get("EDGE_PORT");
+        String s3URL = String.format("http://%s:%s", lsHost, edgePort);
         AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard().
             withEndpointConfiguration(
                 new AwsClientBuilder.EndpointConfiguration(s3URL, region)).


### PR DESCRIPTION
Currently, we use `TEST_S3_URL` in the sample, even though this is not possible any more.
This PR fixes this, by replacing it with the usage of LOCALSTACK_HOSTNAME and EDGE_PORT.