### PR TITLE
Fix broken glue-etl-jobs sample

### DIFF
--- a/glue-etl-jobs/job.py
+++ b/glue-etl-jobs/job.py
@@ -66,7 +66,9 @@ def main():
         m_df = dfc.select(df_name)
         print("Writing to Postgres table:", df_name)
         glueContext.write_dynamic_frame.from_jdbc_conf(
-            frame = m_df, catalog_connection = "c1",
+            frame = m_df,
+            # should be same as CONNECTION_NAME in the bash script
+            catalog_connection = "glue-etl-cluster1-connection",
             connection_options = {"dbtable": df_name, "database": "test"},
             redshift_tmp_dir = redshift_temp_dir)
 

--- a/glue-etl-jobs/run.sh
+++ b/glue-etl-jobs/run.sh
@@ -3,45 +3,45 @@
 BUCKET=glue-pyspark-test
 JOB_NAME=test-job1
 S3_URL=s3://$BUCKET/job.py
+CLUSTER_IDENTIFIER=glue-etl-cluster1
+CONNECTION_NAME=glue-etl-cluster1-connection
 
 echo Putting PySpark script to test S3 bucket ...
-awslocal s3 mb s3://$BUCKET
-awslocal s3 cp job.py $S3_URL
-awslocal s3 mb s3://glue-sample-target
+awslocal s3 mb "s3://$BUCKET"
+awslocal s3 cp "job.py" "$S3_URL"
+awslocal s3 mb "s3://glue-sample-target"
 
-cluster_identifier=glue_etl_cluster1
+awslocal rds create-db-cluster --db-cluster-identifier "$CLUSTER_IDENTIFIER" --engine aurora-postgresql --database-name test
 
-awslocal rds create-db-cluster --db-cluster-identifier $cluster_identifier --engine aurora-postgresql --database-name test
-
-db_port=$(awslocal rds describe-db-clusters --db-cluster-identifier $cluster_identifier) | jq -r '.DBClusters[0].Port'
+db_port=$(awslocal rds describe-db-clusters --db-cluster-identifier "$CLUSTER_IDENTIFIER" | jq -r '.DBClusters[0].Port')
 echo Using local RDS database on port $db_port ...
 
 echo Creating Glue databases and tables ...
 awslocal glue create-database --database-input '{"Name": "legislators"}'
 awslocal glue create-table --database legislators \
-  --table-input '{"Name":"memberships_json", "Parameters": {"connectionName": "$cluster_identifier"}, "StorageDescriptor": {"Location": "test.memberships"}}'
+  --table-input '{"Name": "memberships_json", "Parameters": {"connectionName": "'$CONNECTION_NAME'"}, "StorageDescriptor": {"Location": "test.memberships"}}'
 awslocal glue create-table --database legislators \
-  --table-input '{"Name":"persons_json", "Parameters": {"connectionName": "$cluster_identifier"}, "StorageDescriptor": {"Location": "test.persons"}}'
+  --table-input '{"Name": "persons_json", "Parameters": {"connectionName": "'$CONNECTION_NAME'"}, "StorageDescriptor": {"Location": "test.persons"}}'
 awslocal glue create-table --database legislators \
-  --table-input '{"Name":"organizations_json", "Parameters": {"connectionName": "$cluster_identifier"}, "StorageDescriptor": {"Location": "test.organizations"}}'
+  --table-input '{"Name": "organizations_json", "Parameters": {"connectionName": "'$CONNECTION_NAME'"}, "StorageDescriptor": {"Location": "test.organizations"}}'
 awslocal glue create-connection \
-  --connection-input '{"Name":"$cluster_identifier", "ConnectionType": "JDBC", "ConnectionProperties": {"USERNAME": "test", "PASSWORD": "test", "JDBC_CONNECTION_URL": "jdbc:postgresql://localhost.localstack.cloud:'$db_port'"}}'
+  --connection-input '{"Name": "'$CONNECTION_NAME'", "ConnectionType": "JDBC", "ConnectionProperties": {"USERNAME": "test", "PASSWORD": "test", "JDBC_CONNECTION_URL": "jdbc:postgresql://localhost.localstack.cloud:'$db_port'"}}'
 
 secret=$(awslocal secretsmanager create-secret --name mysecret --secret-string "12345678" | jq -r ".ARN")
 
 echo Creating Postgres database tables with data ...
-awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$cluster_identifier --secret-arn $secret --sql 'CREATE TABLE IF NOT EXISTS persons(id varchar, name varchar)'
-awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$cluster_identifier --secret-arn $secret --sql 'CREATE TABLE IF NOT EXISTS organizations(org_id varchar, org_name varchar)'
-awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$cluster_identifier --secret-arn $secret --sql 'CREATE TABLE IF NOT EXISTS memberships(person_id varchar, organization_id varchar)'
-awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$cluster_identifier --secret-arn $secret --sql "insert into persons(id, name) VALUES('p1', 'person 1')"
-awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$cluster_identifier --secret-arn $secret --sql "insert into organizations(org_id, org_name) VALUES('o1', 'org1')"
-awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$cluster_identifier --secret-arn $secret --sql "insert into memberships(person_id, organization_id) VALUES('p1', 'o1')"
-awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$cluster_identifier --secret-arn $secret --sql 'CREATE TABLE IF NOT EXISTS hist_root(id varchar, name varchar, org_id varchar, org_name varchar, person_id varchar, organization_id varchar)'
+awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$CLUSTER_IDENTIFIER --secret-arn $secret --sql 'CREATE TABLE IF NOT EXISTS persons(id varchar, name varchar)'
+awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$CLUSTER_IDENTIFIER --secret-arn $secret --sql 'CREATE TABLE IF NOT EXISTS organizations(org_id varchar, org_name varchar)'
+awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$CLUSTER_IDENTIFIER --secret-arn $secret --sql 'CREATE TABLE IF NOT EXISTS memberships(person_id varchar, organization_id varchar)'
+awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$CLUSTER_IDENTIFIER --secret-arn $secret --sql "insert into persons(id, name) VALUES('p1', 'person 1')"
+awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$CLUSTER_IDENTIFIER --secret-arn $secret --sql "insert into organizations(org_id, org_name) VALUES('o1', 'org1')"
+awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$CLUSTER_IDENTIFIER --secret-arn $secret --sql "insert into memberships(person_id, organization_id) VALUES('p1', 'o1')"
+awslocal rds-data execute-statement --resource-arn arn:aws:rds:us-east-1:000000000000:cluster:$CLUSTER_IDENTIFIER --secret-arn $secret --sql 'CREATE TABLE IF NOT EXISTS hist_root(id varchar, name varchar, org_id varchar, org_name varchar, person_id varchar, organization_id varchar)'
 
 echo Starting Glue job from PySpark script ...
 awslocal glue create-job --name $JOB_NAME --role r1 \
   --command '{"Name": "pythonshell", "ScriptLocation": "'$S3_URL'"}' \
-  --connections '{"Connections": ["$cluster_identifier"]}'
+  --connections '{"Connections": ["'$CLUSTER_IDENTIFIER'"]}'
 run_id=$(awslocal glue start-job-run --job-name $JOB_NAME | jq -r .JobRunId)
 
 state=$(awslocal glue get-job-run --job-name $JOB_NAME --run-id $run_id | jq -r .JobRun.JobRunState)


### PR DESCRIPTION
(No issue for this PR - it was discussed in Localstack Slack chat.)

This PR addresses the broken glue-etl-jobs sample provided in this repo. The sample should now work with Localstack Pro out of the box.

The changes included are:
* Changed the `CLUSTER_IDENTIFIER` to use dashes (-) instead of underscores (_). Cluster identifiers do not allow underscores.
* Changed the Glue connection name from `"$cluster_identifier"` (likely a typo) to `glue-etl-cluster1-connection`.
* Some bash script changes to better adhere to best practices. It's not perfect, but it's a step in the right direction.
* Changed the python script to reference the correct Glue connection name.
