### PR TITLE
add sample code for lambda runtime interface emulator

### DIFF
--- a/lambda-runtime-interface-emulator/Dockerfile
+++ b/lambda-runtime-interface-emulator/Dockerfile
@@ -1,0 +1,23 @@
+FROM amazonlinux:latest
+
+# Define custom function directory
+ARG FUNCTION_DIR="/function"
+
+# Install ruby
+RUN amazon-linux-extras install -y ruby2.6
+
+# Install bundler
+RUN gem install bundler
+
+# Install the Runtime Interface Client
+RUN gem install aws_lambda_ric
+
+# Copy function code
+RUN mkdir -p ${FUNCTION_DIR}
+RUN mkdir -p /var/rapid
+COPY app.rb ${FUNCTION_DIR}
+
+WORKDIR ${FUNCTION_DIR}
+
+ENTRYPOINT ["/usr/local/bin/aws_lambda_ric"]
+CMD ["app.App::Handler.process"]

--- a/lambda-runtime-interface-emulator/Makefile
+++ b/lambda-runtime-interface-emulator/Makefile
@@ -27,6 +27,7 @@ run:         ## Build, deploy, and invoke the Lambda container image locally
 	awslocal lambda invoke --function-name ruby-lambda-image \
 		--cli-binary-format raw-in-base64-out \
 		--payload '{"test":"test"}' /tmp/lambda.out; \
+	cat /tmp/lambda.out; \
 	echo "Done - test successfully finished."
 
 start:

--- a/lambda-runtime-interface-emulator/Makefile
+++ b/lambda-runtime-interface-emulator/Makefile
@@ -1,0 +1,49 @@
+export AWS_ACCESS_KEY_ID ?= test
+export AWS_SECRET_ACCESS_KEY ?= test
+export AWS_DEFAULT_REGION = us-east-1
+
+usage:       ## Show this help
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+install:     ## Install dependencies
+	@which awslocal || pip install awscli-local
+
+run:         ## Build, deploy, and invoke the Lambda container image locally
+	echo "Creating a new ECR repository locally"; \
+	repoUri=$$(awslocal ecr create-repository --repository-name repo1 | jq -r '.repository.repositoryUri'); \
+	echo "Building the Docker image, pushing it to ECR URL: $$repoUri"; \
+	docker build -t "$$repoUri" .; \
+	docker push "$$repoUri"; \
+	docker rmi "$$repoUri"; \
+	echo "Deploying Lambda function from container image locally"; \
+	awslocal lambda create-function \
+        --function-name ruby-lambda-image \
+        --package-type Image \
+        --code ImageUri=localhost:4510/repo1 \
+		--handler app.App::Handler.process \
+        --role arn:aws:iam::000000000000:role/lambda-r1; \
+	sleep 10;
+	echo "Invoking Lambda function from container image"; \
+	awslocal lambda invoke --function-name ruby-lambda-image \
+		--cli-binary-format raw-in-base64-out \
+		--payload '{"test":"test"}' /tmp/lambda.out; \
+	echo "Done - test successfully finished."
+
+start:
+	PROVIDER_OVERRIDE_LAMBDA=asf localstack start -d
+
+stop:
+	@echo
+	localstack stop
+ready:
+	@echo Waiting on the LocalStack container...
+	@localstack wait -t 30 && echo Localstack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+
+logs:
+	@localstack logs > logs.txt
+
+test-ci:
+	make start install ready run; return_code=`echo $$?`;\
+	make logs; make stop; exit $$return_code;
+	
+.PHONY: usage install start run stop ready logs test-ci

--- a/lambda-runtime-interface-emulator/README.md
+++ b/lambda-runtime-interface-emulator/README.md
@@ -1,0 +1,51 @@
+# Lambda Runtime Interface Emulator with LocalStack
+
+In this example, we will locally test Lambda functions packaged as container images through Lambda Runtime Interface Emulator (RIE) in LocalStack. The Lambda function is implemented in Ruby, and we will use a Docker container image to install the [AWS Lambda Runtime interface emulator](https://github.com/aws/aws-lambda-runtime-interface-emulator), which would be pushed to a local ECR registry, and then deployed as a Lambda function.
+
+## Prerequisites
+
+* LocalStack
+* Docker
+* `make`
+* [`awslocal`](https://github.com/localstack/awscli-local)
+
+## Installing
+
+To install the dependencies:
+
+```sh
+make install
+```
+
+## Running
+
+Make sure that LocalStack is started:
+
+```sh
+PROVIDER_OVERRIDE_LAMBDA=asf LOCALSTACK_API_KEY=... DEBUG=1 localstack start
+```
+
+The following command builds, deploys, and runs the Lambda container image locally:
+
+```sh
+make run
+```
+
+You should see some logs and a success output in the terminal:
+
+```
+$ make run
+Creating a new ECR repository locally
+...
+Invoking Lambda function from container image
+{
+    "StatusCode": 200,
+    "ExecutedVersion": "$LATEST"
+}
+"Hello World!"
+Done - test successfully finished.
+```
+
+## License
+
+This code is available under the Apache 2.0 license.

--- a/lambda-runtime-interface-emulator/app.rb
+++ b/lambda-runtime-interface-emulator/app.rb
@@ -1,0 +1,7 @@
+module App
+    class Handler
+      def self.process(event:, context:)
+        "Hello World!"
+      end
+    end
+  end


### PR DESCRIPTION
## Description

Sample code to solve a customer support ticket. Following references have been used:

- https://github.com/aws/aws-lambda-ruby-runtime-interface-client#creating-a-docker-image-for-lambda-with-the-runtime-interface-client
- https://docs.aws.amazon.com/lambda/latest/dg/images-test.html
- https://docs.aws.amazon.com/lambda/latest/dg/ruby-image.html