### PR TITLE
Fix elb load balancing sample

### DIFF
--- a/elb-load-balancing/package.json
+++ b/elb-load-balancing/package.json
@@ -4,9 +4,8 @@
   "repository": "https://github.com/localstack/localstack-pro-samples",
   "devDependencies": {
     "serverless": "^3.23.0",
-    "serverless-localstack": "^1.0.5",
-    "serverless-pseudo-parameters": "^2.5.0",
-    "serverless-deployment-bucket": "^1.1.0"
+    "serverless-deployment-bucket": "^1.1.0",
+    "serverless-localstack": "^1.0.5"
   },
   "scripts": {
     "deploy": "sls deploy --stage local"

--- a/elb-load-balancing/serverless.yml
+++ b/elb-load-balancing/serverless.yml
@@ -3,7 +3,7 @@ service: test-elb-load-balancing
 provider:
   name: aws
   region: us-east-1
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   deploymentBucket:
     name: testbucket
 
@@ -62,7 +62,6 @@ resources:
 plugins:
   - serverless-deployment-bucket
   - serverless-localstack
-  - serverless-pseudo-parameters
 
 custom:
   localstack:


### PR DESCRIPTION
## Motivation
The elb load balancing sample is broken currently, as also seen in the CI run.

The reason is the `#{host}` definition, which is valid as this parameter for ELB, but is also a serverless pseudo parameter.
Since we also install that project (without using it), it thinks this is a pseudo parameter, and replaces it with a "Fn::Sub" substitution.  (https://github.com/svdgraaf/serverless-pseudo-parameters).

One solution would be to escape this sequence by adding a `@` between the hash symbol and the opening parenthesis, but just removing this plugin seems more straightforward, since we do not use it anyway. The plugin is deprecated anyway, so we can just remove it.

## Changes
* remove serverless pseudo parameters plugin
* Update node version to 14.x, as 12.x is unsupported