### PR TITLE
Major: rename default container name to localstack-main

### DIFF
--- a/java-notification-app/docker-compose.yml
+++ b/java-notification-app/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack-pro
     ports:
       - "127.0.0.1:4510-4559:4510-4559"  # external service port range

--- a/lambda-mounting-and-debugging/javascript/docker-compose.yml
+++ b/lambda-mounting-and-debugging/javascript/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack-pro:latest
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway

--- a/route53-dns-failover/docker-compose.yml
+++ b/route53-dns-failover/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack-pro:2.1.0
     networks:
       sweet_mahavira:

--- a/route53-dns-failover/run_demo.sh
+++ b/route53-dns-failover/run_demo.sh
@@ -75,7 +75,7 @@ awslocal route53 change-resource-record-sets --hosted-zone-id ${HOSTED_ZONE_ID#/
 ]}'
 
 # Get the IP address of the LocalStack container on the Docker bridge
-LOCALSTACK_DNS_SERVER=$(docker inspect localstack_main | jq -r '.[0].NetworkSettings.Networks."route53-dns-failover_sweet_mahavira".IPAddress')
+LOCALSTACK_DNS_SERVER=$(docker inspect localstack-main | jq -r '.[0].NetworkSettings.Networks."route53-dns-failover_sweet_mahavira".IPAddress')
 LOCALSTACK_DNS_SERVER=localhost
 
 # This IP address is used to query the LocalStack DNS server

--- a/sample-archive/spring-cloud-function-microservice/docker-compose.yml
+++ b/sample-archive/spring-cloud-function-microservice/docker-compose.yml
@@ -18,7 +18,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack-pro
     network_mode: bridge
     ports:


### PR DESCRIPTION
# Motivation

Hyphens are not allowed in URLs. When addressing the LocalStack container over a docker network, the container name resolves to the IP address of the container. This is a problem in particular for boto3 which refuses to connect.

# Changes

This PR updates usages of `localstack_main` to `localstack-main`.
