### PR TITLE
Fix appsync sample

### DIFF
--- a/appsync-graphql-api/serverless.yml
+++ b/appsync-graphql-api/serverless.yml
@@ -18,6 +18,7 @@ resources:
         KeySchema:
           - AttributeName: id
             KeyType: HASH
+        BillingMode: PAY_PER_REQUEST
     RDSCluster:
       Type: AWS::RDS::DBCluster
       Properties:

--- a/appsync-graphql-api/serverless.yml
+++ b/appsync-graphql-api/serverless.yml
@@ -84,7 +84,7 @@ custom:
     stages:
       - local
     endpoints:
-      AppSync: http://localhost:4605
+      AppSync: http://localhost:4566
 
 plugins:
   - serverless-localstack


### PR DESCRIPTION
# Motivation

The AppSync sample is out of date for two reasons:

* the dynamodb schema did not specify the billing mode, which therefore defaults to "provisioned" mode, but did not set the read/write capacity units
* the AppSync endpoint in `serverless.yaml` was out of date, pointing to a different port to 4566

# Changes

* Update the dynamodb schema to use the `PAY_PER_REQUEST` mode
* Update the AppSync endpoint to use the LocalStack default port of 4566
