### PR TITLE
Add hot reload deploy options

### DIFF
--- a/lambda-debugging-sam-java/Makefile
+++ b/lambda-debugging-sam-java/Makefile
@@ -58,6 +58,7 @@ deploy-sam:           ## Deploy the Lambda function via AWS SAM CLI
 
 invoke:               ## Invoke the Lambda function and show logs
 	AWS_MAX_ATTEMPTS=1 $(AWS) lambda invoke --function-name $(FUNCTION_NAME) \
+	--cli-binary-format raw-in-base64-out \
 	--payload file://events/event.json \
 	--cli-connect-timeout 3600 \
 	--cli-read-timeout 3600 \

--- a/lambda-debugging-sam-javascript/Makefile
+++ b/lambda-debugging-sam-javascript/Makefile
@@ -1,4 +1,4 @@
-.PHONY: usage install build build-docker build-local build-sam wait deploy deploy-aws deploy-aws-hot-reload deploy-sam invoke clean start stop ready test-ci enable-hot-reload
+.PHONY: usage install build build-docker build-local build-sam wait deploy deploy-aws deploy-aws-hot-reload enable-hot-reload deploy-sam invoke clean start stop ready test-ci
 
 AWS_ENDPOINT_URL ?= http://localhost.localstack.cloud:4566
 AWS ?= AWS_ENDPOINT_URL=$(AWS_ENDPOINT_URL) \
@@ -65,6 +65,12 @@ deploy-aws-hot-reload:           ## Deploy the Lambda function with hot reload v
 	--code S3Bucket="hot-reload",S3Key="/$$PWD/hello-world" \
 	--timeout 2
 
+enable-hot-reload:           ## Enable hot reload via AWS CLI
+	$(AWS) lambda update-function-code \
+	--function-name $(FUNCTION_NAME) \
+	--s3-bucket "hot-reload" \
+	--s3-key "$$PWD/hello-world"
+
 deploy-sam:           ## Deploy the Lambda function via AWS SAM CLI
 	$(SAM) deploy
 
@@ -98,9 +104,3 @@ ready:                ## Wait until LocalStack is running
 test-ci:
 	make start install ready deploy wait invoke; return_code=`echo $$?`;\
 	echo "Interactive debugging not tested in CI"; exit $$return_code;
-
-enable-hot-reload:           ## Enable hot reload via AWS CLI
-	$(AWS) lambda update-function-code \
-	--function-name $(FUNCTION_NAME) \
-	--s3-bucket "hot-reload" \
-	--s3-key "$$PWD/hello-world"

--- a/lambda-debugging-sam-javascript/Makefile
+++ b/lambda-debugging-sam-javascript/Makefile
@@ -1,4 +1,4 @@
-.PHONY: usage install build build-docker build-local build-sam wait deploy deploy-aws deploy-sam invoke clean start stop ready test-ci
+.PHONY: usage install build build-docker build-local build-sam wait deploy deploy-aws deploy-aws-hot-reload deploy-sam invoke clean start stop ready test-ci enable-hot-reload
 
 AWS_ENDPOINT_URL ?= http://localhost.localstack.cloud:4566
 AWS ?= AWS_ENDPOINT_URL=$(AWS_ENDPOINT_URL) \
@@ -56,11 +56,21 @@ deploy-aws:           ## Deploy the Lambda function via AWS CLI
 	--zip-file fileb://hello-world/hello-world-javascript.zip \
 	--timeout 2
 
+deploy-aws-hot-reload:           ## Deploy the Lambda function with hot reload via AWS CLI
+	$(AWS) lambda create-function \
+	--function-name $(FUNCTION_NAME) \
+	--runtime $(LAMBDA_RUNTIME) \
+	--role arn:aws:iam::000000000000:role/lambda-role \
+	--handler app.lambdaHandler \
+	--code S3Bucket="hot-reload",S3Key="/$$PWD/hello-world" \
+	--timeout 2
+
 deploy-sam:           ## Deploy the Lambda function via AWS SAM CLI
 	$(SAM) deploy
 
 invoke:               ## Invoke the Lambda function and show logs
 	AWS_MAX_ATTEMPTS=1 $(AWS) lambda invoke --function-name $(FUNCTION_NAME) \
+	--cli-binary-format raw-in-base64-out \
 	--payload file://events/event.json \
 	--cli-connect-timeout 3600 \
 	--cli-read-timeout 3600 \
@@ -88,3 +98,9 @@ ready:                ## Wait until LocalStack is running
 test-ci:
 	make start install ready deploy wait invoke; return_code=`echo $$?`;\
 	echo "Interactive debugging not tested in CI"; exit $$return_code;
+
+enable-hot-reload:           ## Enable hot reload via AWS CLI
+	$(AWS) lambda update-function-code \
+	--function-name $(FUNCTION_NAME) \
+	--s3-bucket "hot-reload" \
+	--s3-key "$$PWD/hello-world"

--- a/lambda-debugging-sam-python/Makefile
+++ b/lambda-debugging-sam-python/Makefile
@@ -76,6 +76,7 @@ deploy-sam:           ## Deploy the Lambda function via AWS SAM CLI
 
 invoke:               ## Invoke the Lambda function and show logs
 	AWS_MAX_ATTEMPTS=1 $(AWS) lambda invoke --function-name $(FUNCTION_NAME) \
+	--cli-binary-format raw-in-base64-out \
 	--payload file://events/event.json \
 	--cli-connect-timeout 3600 \
 	--cli-read-timeout 3600 \

--- a/lambda-debugging-sam-python/Makefile
+++ b/lambda-debugging-sam-python/Makefile
@@ -1,4 +1,4 @@
-.PHONY: usage install build build-docker build-local build-sam wait deploy deploy-aws deploy-sam invoke clean start stop ready test-ci
+.PHONY: usage install build build-docker build-local build-sam wait deploy deploy-aws deploy-aws-hot-reload enable-hot-reload deploy-sam invoke clean start stop ready test-ci
 
 AWS_ENDPOINT_URL ?= http://localhost.localstack.cloud:4566
 AWS ?= AWS_ENDPOINT_URL=$(AWS_ENDPOINT_URL) \
@@ -55,6 +55,21 @@ deploy-aws:           ## Deploy the Lambda function via AWS CLI
 	--handler app.lambda_handler \
 	--zip-file fileb://hello_world/hello_world_python.zip \
 	--timeout 2
+
+deploy-aws-hot-reload:           ## Deploy the Lambda function with hot reload via AWS CLI
+	$(AWS) lambda create-function \
+	--function-name $(FUNCTION_NAME) \
+	--runtime $(LAMBDA_RUNTIME) \
+	--role arn:aws:iam::000000000000:role/lambda-role \
+	--handler app.lambda_handler \
+	--code S3Bucket="hot-reload",S3Key="/$$PWD/hello_world" \
+	--timeout 2
+
+enable-hot-reload:           ## Enable hot reload via AWS CLI
+	$(AWS) lambda update-function-code \
+	--function-name $(FUNCTION_NAME) \
+	--s3-bucket "hot-reload" \
+	--s3-key "$$PWD/hello_world"
 
 deploy-sam:           ## Deploy the Lambda function via AWS SAM CLI
 	$(SAM) deploy

--- a/lambda-debugging-sam-typescript/Makefile
+++ b/lambda-debugging-sam-typescript/Makefile
@@ -62,6 +62,7 @@ deploy-sam:           ## Deploy the Lambda function via AWS SAM CLI
 
 invoke:               ## Invoke the Lambda function and show logs
 	AWS_MAX_ATTEMPTS=1 $(AWS) lambda invoke --function-name $(FUNCTION_NAME) \
+	--cli-binary-format raw-in-base64-out \
 	--payload file://events/event.json \
 	--cli-connect-timeout 3600 \
 	--cli-read-timeout 3600 \


### PR DESCRIPTION
The hot reload feature enables quick iterations, and combining it with Lambda remote debugging improves DevX for quick iterations.

## Testing

I tested both new make targets `deploy-aws-hot-reload` and `enable-hot-reload` for both the javascript and the python sample. It works with remote invokes as well as VSCode debugging.

## Related

Fixes DRG-446
