### PR TITLE
Issue#262-Migrate from API Key to Auth Token for sample tests

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Execute tests
       env:
-        LOCALSTACK_API_KEY: ${{ secrets.TEST_LOCALSTACK_API_KEY }}
+        LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}
         DNS_ADDRESS: 127.0.0.1
         DEBUG: 1
       timeout-minutes: 200

--- a/emr-serverless-python-dependencies/docker-compose.yml
+++ b/emr-serverless-python-dependencies/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       # Activate LocalStack Pro: https://docs.localstack.cloud/getting-started/auth-token/
       - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}  # required for Pro
-      - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY:-}  # required for CI
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}  # required for CI
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
       - PERSISTENCE=${PERSISTENCE:-0}


### PR DESCRIPTION
- Identified `LOCALSTACK_API_KEY` in two files:
  - [emr-serverless-python-dependencies/docker-compose.yml](https://github.com/localstack-samples/localstack-pro-samples/blob/8675302abce693b6d151235162362cffbfd43de1/emr-serverless-python-dependencies/docker-compose.yml#L14)
  - [.github/workflows/makefile.yml](https://github.com/localstack-samples/localstack-pro-samples/blob/8675302abce693b6d151235162362cffbfd43de1/.github/workflows/makefile.yml#L47)
  
- Replaced the `LOCALSTACK_API_KEY` with `LOCALSTACK_AUTH_TOKEN` 
- Tested  locally:
  - `emr-serverless-python-dependencies/docker-compose.yml` using `docker compose up`
  - `.github/workflows/makefile.yml` using `make test-ci-all`
- Test were successful, other than the fact that I don't have an active LocalStack license.