### PR TITLE
Testcontainers Java sample: fix test assertions and wait loop, modernize JDBC/JUnit, and clean up POM

### DIFF
--- a/testcontainers-java-sample/LocalStackTestcontainers/pom.xml
+++ b/testcontainers-java-sample/LocalStackTestcontainers/pom.xml
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.17.224</version>
+                <version>2.25.62</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -40,10 +40,6 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>s3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
             <artifactId>cognitoidentity</artifactId>
         </dependency>
         <dependency>
@@ -53,20 +49,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>localstack</artifactId>
-            <version>1.19.2</version>
-            <scope>test</scope>
-
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.11.914</version>
+            <version>1.20.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.3-1100-jdbc4</version>
+            <version>42.7.4</version>
         </dependency>
     </dependencies>
     <build>

--- a/testcontainers-java-sample/LocalStackTestcontainers/src/main/java/RDS.java
+++ b/testcontainers-java-sample/LocalStackTestcontainers/src/main/java/RDS.java
@@ -24,28 +24,27 @@ public class RDS {
             String url = String.format("jdbc:postgresql://%s:%d/%s", hostname, port, dbname);
             c = DriverManager.getConnection(url, DEFAULT_USER, DEFAULT_PW);
             c.setAutoCommit(true);
-            Statement stmt = c.createStatement();
-            String sql = "CREATE TABLE HELLO " +
-                    "(ID INT PRIMARY KEY     NOT NULL," +
-                    " NAME           TEXT    NOT NULL) ";
-            stmt.executeUpdate(sql);
+            try (Statement stmt = c.createStatement()) {
+                String sql = "CREATE TABLE HELLO " +
+                        "(ID INT PRIMARY KEY     NOT NULL," +
+                        " NAME           TEXT    NOT NULL) ";
+                stmt.executeUpdate(sql);
 
-            sql = "INSERT INTO HELLO (ID,NAME) "
-                    + "VALUES (1, 'world');";
-            stmt.executeUpdate(sql);
-            ResultSet rs = stmt.executeQuery( "SELECT * FROM HELLO;" );
-            String response = "";
-            while( rs.next()) {
-                int id = rs.getInt("id");
-                String name = rs.getString("name");
-                response += String.format("ID = %d\nNAME = %s", id, name);
+                sql = "INSERT INTO HELLO (ID,NAME) VALUES (1, 'world');";
+                stmt.executeUpdate(sql);
+                String response = "";
+                try (ResultSet rs = stmt.executeQuery("SELECT * FROM HELLO;")) {
+                    while (rs.next()) {
+                        int id = rs.getInt("id");
+                        String name = rs.getString("name");
+                        response += String.format("ID = %d\nNAME = %s", id, name);
+                    }
+                }
+                return response;
             }
-            rs.close();
-            stmt.close();
-            return response;
         } finally {
             try {
-                c.close();
+                if (c != null) c.close();
             } catch (SQLException e) {
                 // we can ignore error here
             }

--- a/testcontainers-java-sample/LocalStackTestcontainers/src/test/java/TestRDS.java
+++ b/testcontainers-java-sample/LocalStackTestcontainers/src/test/java/TestRDS.java
@@ -30,9 +30,9 @@ public class TestRDS {
      */
     @Rule
     public LocalStackContainer localstack = new LocalStackContainer(localstackImage)
-                                                        .withExposedPorts(4510, 4511, 4512, 4513, 4514) // TODO the port can have any value between 4510-4559, but LS starts from 4510
-                                                        .withEnv("LOCALSTACK_AUTH_TOKEN", api_key) // TODO add your Auth Token here
-                                                        .withServices(LocalStackContainer.EnabledService.named("rds"));
+            .withExposedPorts(4510, 4511, 4512, 4513, 4514) // TODO the port can have any value between 4510-4559, but LS starts from 4510
+            .withEnv("LOCALSTACK_AUTH_TOKEN", api_key) // TODO add your Auth Token here
+            .withServices(LocalStackContainer.EnabledService.named("rds"));
 
 
     @Test
@@ -51,8 +51,19 @@ public class TestRDS {
         DescribeDbInstancesRequest request = DescribeDbInstancesRequest.builder().dbInstanceIdentifier(identifier).build();
         DescribeDbInstancesResponse describedb = rds.describeDBInstances(request);
 
-        // wait for db to be ready
-        while(! describedb.dbInstances().get(0).dbInstanceStatus().equalsIgnoreCase("available")) {
+        // wait for db to be ready with a small backoff and a timeout to avoid busy-waiting
+        long start = System.currentTimeMillis();
+        long timeoutMs = 30_000; // 30s
+        while (!describedb.dbInstances().get(0).dbInstanceStatus().equalsIgnoreCase("available")) {
+            if (System.currentTimeMillis() - start > timeoutMs) {
+                fail("Timed out waiting for RDS instance to become available");
+            }
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                fail("Interrupted while waiting for RDS instance to become available");
+            }
             describedb = rds.describeDBInstances(request);
         }
 
@@ -65,7 +76,8 @@ public class TestRDS {
             // try to connect to database in our example we simply insert some dummy data
             String actual = RDS.test_connection(localstack.getHost(), mapped_port, "hello");
             String expected = "ID = 1\nNAME = world";
-            assertEquals(actual, expected);
+            // JUnit expects (expected, actual)
+            assertEquals(expected, actual);
         } catch (Exception e) {
             fail("testing connection with database failed");
         }

--- a/testcontainers-java-sample/README.md
+++ b/testcontainers-java-sample/README.md
@@ -1,14 +1,22 @@
 # Example using RDS with Localstack Testcontainers
 
-Testcontainers need a special setup to use services like RDS, which may use any port to expose the database.
-The sample explains how the mapping works, and how you need to configure Testcontainers in order to connect to the RDS instance from your test.
+Testcontainers need a special setup to use services like RDS, which may use any port to expose the database. The sample explains how the mapping works, and how you need to configure Testcontainers in order to connect to the RDS instance from your test.
+
+## Prerequisites
+- Docker running
+- JDK 11+
+- Maven 3.8+
+- LocalStack Pro Auth Token in `LOCALSTACK_AUTH_TOKEN`
 
 ## Run Example
-* Import the project (e.g. in IntelliJ), 
-* configure your LOCALSTACK_AUTH_TOKEN as environment variable, 
-* and then run  the test `TestRDS`.
+You can run the JUnit test either in your IDE or from the command line:
 
-It will create a LocalStack Testcontainer and a postgres database instance using RDSClient.
-The database will then be filled with some data, and queried afterwards. 
+```
+cd testcontainers-java-sample/LocalStackTestcontainers
+export LOCALSTACK_AUTH_TOKEN=...  # required for RDS (Pro feature)
+mvn -q -Dtest=TestRDS test
+```
+
+This will start a LocalStack Testcontainers instance, create a Postgres database via the RDS client, insert a row, and query it.
 
 


### PR DESCRIPTION
**Test stability and correctness**

- > Add a small sleep and a timeout in the “wait until DB is available” loop to avoid busy-waiting forever on a failing setup.
- > Fix assertEquals argument order (expected first, then actual) in TestRDS.

**Code hygiene**

- > Use try-with-resources for Statement and ResultSet in RDS.test_connection to ensure they are reliably closed.

**Dependency updates and cleanups (in pom.xml)**

- > Remove duplicate software.amazon.awssdk:s3 entry.
- > Remove unused AWS SDK v1 test dependency (com.amazonaws:aws-java-sdk-s3). Project already uses AWS SDK v2.
- > Update JUnit 4 to 4.13.2 (latest 4.x) to address old CVEs.
- > Update PostgreSQL JDBC driver to a modern version (e.g., 42.7.4).
- > Optionally update Testcontainers LocalStack module and AWS SDK v2 BOM to recent stable versions.

**README**

- > Add direct CLI instructions to run the test without an IDE (mvn -q -Dtest=TestRDS test).
- > Explicitly document prerequisites (Docker running, LocalStack Pro token) and how credentials are provided in the test.
