### PR TITLE
Migrate from deprecated LOCALSTACK_API_KEY to LOCALSTACK_AUTH_TOKEN

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Execute tests
       env:
-        LOCALSTACK_API_KEY: ${{ secrets.TEST_LOCALSTACK_API_KEY }}
+        LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}
         DNS_ADDRESS: 127.0.0.1
         DEBUG: 1
       timeout-minutes: 200

--- a/emr-serverless-python-dependencies/docker-compose.yml
+++ b/emr-serverless-python-dependencies/docker-compose.yml
@@ -11,7 +11,6 @@ services:
     environment:
       # Activate LocalStack Pro: https://docs.localstack.cloud/getting-started/auth-token/
       - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}  # required for Pro
-      - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY:-}  # required for CI
       # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
       - DEBUG=${DEBUG:-0}
       - PERSISTENCE=${PERSISTENCE:-0}

--- a/java-notification-app/README.md
+++ b/java-notification-app/README.md
@@ -29,7 +29,7 @@ Resources are deployed via a CloudFormation template in `src/main/resources/emai
 
 First, start LocalStack and the SMTP server with:
 
-    LOCALSTACK_AUTH_TOKEN=<your-api-key> docker-compose up -d
+    LOCALSTACK_AUTH_TOKEN=<your-auth-token> docker-compose up -d
 
 Then deploy the cloudformation stack (can take a few seconds)
 

--- a/route53-dns-failover/README.md
+++ b/route53-dns-failover/README.md
@@ -5,7 +5,7 @@ We suggest taking a look at [run.sh](run.sh) script to understand the setup.
 To run the demo:
 
 ```
-$ LOCALSTACK_AUTH_TOKEN=<your-api-key> docker-compose up -d
+$ LOCALSTACK_AUTH_TOKEN=<your-auth-token> docker-compose up -d
 ```
 
 ```

--- a/sample-archive/spring-cloud-function-microservice/.env.example
+++ b/sample-archive/spring-cloud-function-microservice/.env.example
@@ -1,1 +1,1 @@
-LOCALSTACK_AUTH_TOKEN=<your-pro=api-key>
+LOCALSTACK_AUTH_TOKEN=<your-auth-token>

--- a/testcontainers-java-sample/LocalStackTestcontainers/src/test/java/TestRDS.java
+++ b/testcontainers-java-sample/LocalStackTestcontainers/src/test/java/TestRDS.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.fail;
 public class TestRDS {
 
     private DockerImageName localstackImage = DockerImageName.parse("localstack/localstack-pro:latest");
-    private String api_key = System.getenv("LOCALSTACK_AUTH_TOKEN");
+    private String authToken = System.getenv("LOCALSTACK_AUTH_TOKEN");
 
     /**
      * Start LocalStackContainer with exposed Ports. Those ports are used by services like RDS, where several databases can be started, running on different ports.
@@ -31,7 +31,7 @@ public class TestRDS {
     @Rule
     public LocalStackContainer localstack = new LocalStackContainer(localstackImage)
                                                         .withExposedPorts(4510, 4511, 4512, 4513, 4514) // TODO the port can have any value between 4510-4559, but LS starts from 4510
-                                                        .withEnv("LOCALSTACK_AUTH_TOKEN", api_key) // TODO add your Auth Token here
+                                                        .withEnv("LOCALSTACK_AUTH_TOKEN", authToken) // TODO add your Auth Token here
                                                         .withServices(LocalStackContainer.EnabledService.named("rds"));
 
 


### PR DESCRIPTION
## Summary
This PR migrates all usages of the deprecated `LOCALSTACK_API_KEY` environment variable to the new `LOCALSTACK_AUTH_TOKEN` to ensure continued authentication with LocalStack Pro services.

## Background
The `LOCALSTACK_API_KEY` has been sunset and will no longer work for authentication. Without this migration, sample tests will fail due to authentication errors since the API key mechanism is deprecated. FIXES #262 

## Changes Made

### Core Migration
- **`.github/workflows/makefile.yml`**: Updated CI workflow to use `LOCALSTACK_AUTH_TOKEN` instead of `LOCALSTACK_API_KEY`
- **`emr-serverless-python-dependencies/docker-compose.yml`**: Removed deprecated `LOCALSTACK_API_KEY` environment variable

### Documentation Updates
- **`testcontainers-java-sample/LocalStackTestcontainers/src/test/java/TestRDS.java`**: Updated variable name from `api_key` to `authToken` for consistency
- **`sample-archive/spring-cloud-function-microservice/.env.example`**: Updated placeholder format from `<your-pro=api-key>` to `<your-auth-token>`
- **`java-notification-app/README.md`**: Updated documentation to use `<your-auth-token>` format
- **`route53-dns-failover/README.md`**: Updated documentation to use `<your-auth-token>` format

## Testing Steps

### 1. Verification of Migration
```bash
# Confirmed no LOCALSTACK_API_KEY references remain
grep -r "LOCALSTACK_API_KEY" . --exclude-dir=.git
# Result: No matches found ✅

# Verified LOCALSTACK_AUTH_TOKEN is properly used
grep -r "LOCALSTACK_AUTH_TOKEN" . --exclude-dir=.git | wc -l
# Result: 40+ references found ✅
```

### 2. Local Testing
```bash
# Set up environment
export LOCALSTACK_AUTH_TOKEN=<auth-token>
pip install localstack[pro] awscli-local

# Test basic functionality
localstack start -d
localstack wait -t 30
awslocal s3 mb s3://test-migration
awslocal s3 ls
localstack stop
# Result: No authentication errors ✅
```

### 3. Sample Testing
```bash
# Test terraform sample
cd terraform-resources
export LOCALSTACK_AUTH_TOKEN=<auth-token>
make start && make ready && make run && make stop
# Result: Sample completed successfully ✅

# Test serverless sample  
cd serverless-lambda-layers
make test-ci
# Result: Lambda deployment and invocation successful ✅
```

### 4. Docker Compose Testing
```bash
# Test docker-compose integration
cd java-notification-app
export LOCALSTACK_AUTH_TOKEN=<auth-token>
docker-compose up -d
docker-compose logs localstack | grep -i error
# Result: No authentication errors in logs ✅
```

### 5. CI Workflow Validation
- Verified GitHub workflow uses `LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}`
- Confirmed secret name change from `TEST_LOCALSTACK_API_KEY` to `TEST_LOCALSTACK_AUTH_TOKEN`

## Impact
- ✅ All sample tests will continue to work with LocalStack Pro
- ✅ No breaking changes for users (they just need to use the new environment variable)
- ✅ Consistent authentication mechanism across all samples