### PR TITLE
Migrate elb-load-balancing sample to the lstk CLI

### DIFF
--- a/elb-load-balancing/Makefile
+++ b/elb-load-balancing/Makefile
@@ -8,20 +8,19 @@ usage:       ## Show this help
 check:    ## Check if all required prerequisites are installed
 	@command -v docker > /dev/null 2>&1 || { echo "Docker is not installed. Please install Docker and try again."; exit 1; }
 	@command -v node > /dev/null 2>&1 || { echo "Node.js is not installed. Please install Node.js and try again."; exit 1; }
-	@command -v localstack > /dev/null 2>&1 || { echo "LocalStack CLI is not installed. Please install it and try again."; exit 1; }
-	@command -v awslocal > /dev/null 2>&1 || { echo "awslocal is not installed. Please run: pip install awscli-local"; exit 1; }
+	@command -v lstk > /dev/null 2>&1 || { echo "lstk CLI is not installed. Please run: npm install -g @localstack/lstk"; exit 1; }
+	@command -v aws > /dev/null 2>&1 || { echo "AWS CLI is not installed (required by 'lstk aws'). Please install it and try again."; exit 1; }
 	@echo "All required prerequisites are available."
 
 
 install:     ## Install dependencies
 	@npm install
 	@which serverless || npm install -g serverless
-	@which localstack || pip install localstack
-	@which awslocal || pip install awscli-local
+	@which lstk || npm install -g @localstack/lstk
 
 run:         ## Deploy the app locally and run a Lambda test invocation
 	echo "Deploying Serverless app to local environment"; \
-	awslocal s3api create-bucket --bucket testbucket; \
+	lstk aws s3api create-bucket --bucket testbucket; \
 	SLS_DEBUG=1 npm run deploy && \
 	echo "Serverless app successfully deployed. Now trying to invoke the Lambda functions via ELB endpoint." && \
 	echo && echo "Invoking endpoint 1: http://lb-test-1.elb.localhost.localstack.cloud:4566/hello1" && \
@@ -32,21 +31,20 @@ run:         ## Deploy the app locally and run a Lambda test invocation
 
 start:
 	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
-	DEBUG=1 LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+	LOCALSTACK_DEBUG=1 LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) lstk start --non-interactive --type aws
 
 stop:
 	@echo
-	localstack stop
+	lstk stop
 ready:
 	@echo Waiting on the LocalStack container...
-	@localstack wait -t 30 && echo Localstack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+	@lstk status > /dev/null && echo Localstack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
 
 logs:
-	@localstack logs > logs.txt
+	@lstk logs > logs.txt
 
 test-ci:
-	make start install ready run; return_code=`echo $$?`;\
+	make install start ready run; return_code=`echo $$?`;\
 	make logs; make stop; exit $$return_code;
-	
-.PHONY: usage install start run stop ready logs test-ci
 
+.PHONY: usage install start run stop ready logs test-ci

--- a/elb-load-balancing/README.md
+++ b/elb-load-balancing/README.md
@@ -14,7 +14,8 @@ A demo application illustrating ELBv2 Application Load Balancers using LocalStac
 
 - A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
 - [Docker](https://docs.docker.com/get-docker/)
-- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli)
+- [`lstk` CLI](https://docs.localstack.cloud/aws/developer-tools/running-localstack/lstk/)
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) (required by `lstk aws`)
 - [Node.js](https://nodejs.org/en/download/) with `npm`
 - [Serverless Framework](https://www.serverless.com/framework/docs/getting-started)
 


### PR DESCRIPTION
Migrates the `elb-load-balancing` sample from the `localstack` CLI and the `awslocal` wrapper to `lstk`. Note that the CI tests failures in GitHub Actions are unrelated to this change.

## Command mapping

| Before | After |
| --- | --- |
| `awslocal s3api create-bucket` | `lstk aws s3api create-bucket` |
| `DEBUG=1 localstack start -d` | `LOCALSTACK_DEBUG=1 lstk start --non-interactive --type aws` |
| `localstack wait -t 30` | `lstk status` |
| `localstack logs` / `localstack stop` | `lstk logs` / `lstk stop` |
| `pip install localstack awscli-local` | `npm install -g @localstack/lstk` |

## Testing

Verified end to end against a running emulator: `make check`, `install`, `start`, `ready`, `run`, `logs` and `stop` all pass, and both ELB endpoints return `Hello 1` / `Hello 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)