### PR TITLE
Fix all sample CI failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,13 @@ jobs:
           node-version: 20
 
       - name: Install LocalStack
-        run: pip install localstack awscli-local[ver1] virtualenv
+        # boto3 is named explicitly and -U is required: the runner image ships
+        # Ubuntu's python3-boto3 (1.34.46) in /usr/lib/python3/dist-packages, which
+        # otherwise satisfies the requirement and leaves Debian's debundled botocore
+        # in place. That botocore has botocore/vendored/ stripped, and awscli v1
+        # imports botocore.vendored.requests, so every awslocal call aborts with
+        # "ModuleNotFoundError: No module named 'botocore.vendored'".
+        run: pip install -U localstack awscli-local[ver1] boto3 virtualenv
 
       - name: Setup config
         run: |

--- a/emr-serverless-python-dependencies/Dockerfile-localstack
+++ b/emr-serverless-python-dependencies/Dockerfile-localstack
@@ -3,6 +3,16 @@
 ## ----------------------------------------------------------------------------
 FROM --platform=linux/amd64 localstack/localstack:latest AS base
 
+# The LocalStack image is Debian-based, and Debian splits ensurepip out of the
+# stdlib into a separate pythonX.Y-venv package. Without it `python3 -m venv`
+# fails, both for the venv below and for the one poetry-plugin-bundle creates.
+# The version is derived from the image's interpreter rather than hardcoded so
+# this keeps working as the base image's Python moves on.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        "python$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')-venv" \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/terraform-resources/test.tf
+++ b/terraform-resources/test.tf
@@ -1,3 +1,17 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # Pinned below 6.57.0: that release added a state waiter to
+      # aws_api_gateway_rest_api which polls for a field LocalStack does not
+      # return, so creation fails with "unexpected state '', wanted target
+      # 'AVAILABLE'". Without a constraint here, terraform init picks up the
+      # latest provider and the sample breaks.
+      version = "~> 6.56.0"
+    }
+  }
+}
+
 provider "aws" {
   access_key                  = "mock_access_key"
   secret_key                  = "mock_secret_key"


### PR DESCRIPTION
Fix test failures that occurred due to changes in third-party dependencies.

| Sample(s) | Cause |
| --- | --- |
| ~16 samples | `awslocal` aborts on the runner's debundled distro botocore |
| `emr-serverless-python-dependencies` | Debian split `ensurepip` out of the stdlib |
| `terraform-resources` | AWS provider 6.57.0 added a state waiter LocalStack can't satisfy |

🤖 Generated with [Claude Code](https://claude.com/claude-code)